### PR TITLE
make TDR and related commands/function obsolete

### DIFF
--- a/Packages/CANVASDRAW.n
+++ b/Packages/CANVASDRAW.n
@@ -5,8 +5,7 @@ OpticsPlot;
 
 FFSCanvasDraw=Class[{},{},{},
 
-  Draw[]:=If[$DisplayFunction===TopDrawer,
-    1,
+  Draw[]:=If[$DisplayFunction===CanvasDrawer,
     Module[{w,r1,r2,list,w1,opt,w1u},
       w=Read[-1,Word,ReadNewRecord->False];
       If[ToUpperCase[w]==="DRAW",
@@ -53,7 +52,9 @@ FFSCanvasDraw=Class[{},{},{},
       OpticsPlot[list,Null@@opt,PlotLabel->TITLE];
       Update[];
 !      Print[{w,w1}];
-      If[w1==";","",w]]];      
+      If[w1==";","",w]]
+      , 1
+      ];      
 
   SeparateAmpsnd[w_]:=Module[{p=StringPosition[w,"&"]/.{}->{{Infinity,Infinity}},
     q=StringPosition[w,";"]/.{}->{{Infinity,Infinity}}},

--- a/Packages/HelpMessages.n
+++ b/Packages/HelpMessages.n
@@ -1501,13 +1501,13 @@ prints out the TopDrawer commands for the geometric plot of the beam line.",
     "DISPLAY(DISP)",
     {}},
 
-   {"TDR",
-    "Usage:   TDR {filename | file_number}\n\n\
-runs TopDrawer (tdr) using the file specified by filename or file_number as the input. It supports both Tek terminal and X-window.\n\n\
-Example:   OUT 'a' DRAW bx by & ex ey q* CLOSE OUT TDR 'a'\n\n\
-TDR does not work when SAD is running under EMACS without X-window.",
-    "DRAW GEO OUTPUT(OUT) CLOSE(CLO)",
-    {}},
+!    {"TDR",
+!     "Usage:   TDR {filename | file_number}\n\n\
+! runs TopDrawer (tdr) using the file specified by filename or file_number as the input. It supports both Tek terminal and X-window.\n\n\
+! Example:   OUT 'a' DRAW bx by & ex ey q* CLOSE OUT TDR 'a'\n\n\
+! TDR does not work when SAD is running under EMACS without X-window.",
+!     "DRAW GEO OUTPUT(OUT) CLOSE(CLO)",
+!     {}},
 
    {"PRINT(PRI)",
     "PRI expression evaluates expression and prints out the result.",

--- a/Packages/OpticsPlot.n
+++ b/Packages/OpticsPlot.n
@@ -170,9 +170,11 @@ OP$InfoLabel[canvas_Widget,frid_Real,bind_:True]:=Module[{
       ];
     KBF$MoveCBForInfoLabel[t]]];
 
-With[{tdr:=TopDrawer,cdr:=CanvasDrawer},
+
+!With[{tdr:=TopDrawer,cdr:=CanvasDrawer},
+With[{cdr:=CanvasDrawer},
   SetAttributes[PlotColorDefault,HoldAll];
-  PlotColorDefault[tdr]={"black"};
+  (* PlotColorDefault[tdr]={"black"}; *)
   PlotColorDefault[cdr]=
     {"dark slate blue","red3","forest green","goldenrod","purple"};
   SetAttributes[PlotColorDefault,HoldNone]];
@@ -572,46 +574,48 @@ Twiss$Unit[x_String?(#[1,3]==="SIG"&)]:=Module[
   Twiss$Unit[x]=u];
 Twiss$Unit[_]=1;
 
-If[$DisplayFunction===Unevaluated[TopDrawer],
-  Twiss$Unit$Label[Meter]={"M","L"};
-  Twiss$Unit$Label[Kilometer]={"KM","LL"};
-  Twiss$Unit$Label[Milimeter]={"MM","LL"};
-  Twiss$Unit$Label[Micron]={"MM","GL"};
-  Twiss$Unit$Label[Nanometer]={"NM","LL"};
-  Twiss$Unit$Label[Miliradian]={"MRAD","LLLL"};
-  Twiss$Unit$Label[Microradian]={"MRAD","GLLL"};
-  Twiss$Unit$Label[Radian]={"RAD","LLL"};
-  Twiss$Unit$Label[SqrtMeter]={"2M062O1","MLUUUDU"};
-  Twiss$Unit$Label[SquareMeter]={"M223","LX X"};
-  Twiss$Unit$Label[InvMeter]={"M2-13","LX  X"};
-  Twiss$Unit$Label[InvKilometer]={"KM2-13","LLX  X"};
-  Twiss$Unit$Label[Pi2]={"2P"," G"};
-  Twiss$Unit$Label[_]={"",""};
-  Twiss$Label["AX"]={"A0X1","GXLX"};
-  Twiss$Label["BX"]={"2B06O0X1","MGUUDXLX"};
-  Twiss$Label["NX"]={"M0X1","GXLX"};
-  Twiss$Label["EX"]={"H0X1","GXLX"};
-  Twiss$Label["EPX"]={"HA0X1","GPXLX"};
-  Twiss$Label["PEX"]={"H0XP1","GXL X"};
-  Twiss$Label["PEPX"]={"HA0XP1","GPXL X"};
-  Twiss$Label["DX"]={"DX","FL"};
-  Twiss$Label["DPX"]={"DXA","FLP"};
-  Twiss$Label["AY"]={"A0Y1","GXLX"};
-  Twiss$Label["BY"]={"2B06O0Y1","MGUUDXLX"};
-  Twiss$Label["NY"]={"M0Y1","GXLX"};
-  Twiss$Label["EY"]={"H0Y1","GXLX"};
-  Twiss$Label["EPY"]={"HA0Y1","GPXLX"};
-  Twiss$Label["PEY"]={"H0YP1","GXL X"};
-  Twiss$Label["PEPY"]={"HA0YP1","GPXL X"};
-  Twiss$Label["DY"]={"DY","FL"};
-  Twiss$Label["DPY"]={"DYA","FLP"};
-  Twiss$Label["DZ"]={"DZ","FL"};
-  Twiss$Label["R1"]={"R1","  "};
-  Twiss$Label["R2"]={"R2","  "};
-  Twiss$Label["R3"]={"R3","  "};
-  Twiss$Label["R4"]={"R4","  "};
-  Twiss$Label["DETR"]={"DETR"," LL "},
+! If[$DisplayFunction===Unevaluated[TopDrawer],
+!   Twiss$Unit$Label[Meter]={"M","L"};
+!   Twiss$Unit$Label[Kilometer]={"KM","LL"};
+!   Twiss$Unit$Label[Milimeter]={"MM","LL"};
+!   Twiss$Unit$Label[Micron]={"MM","GL"};
+!   Twiss$Unit$Label[Nanometer]={"NM","LL"};
+!   Twiss$Unit$Label[Miliradian]={"MRAD","LLLL"};
+!   Twiss$Unit$Label[Microradian]={"MRAD","GLLL"};
+!   Twiss$Unit$Label[Radian]={"RAD","LLL"};
+!   Twiss$Unit$Label[SqrtMeter]={"2M062O1","MLUUUDU"};
+!   Twiss$Unit$Label[SquareMeter]={"M223","LX X"};
+!   Twiss$Unit$Label[InvMeter]={"M2-13","LX  X"};
+!   Twiss$Unit$Label[InvKilometer]={"KM2-13","LLX  X"};
+!   Twiss$Unit$Label[Pi2]={"2P"," G"};
+!   Twiss$Unit$Label[_]={"",""};
+!   Twiss$Label["AX"]={"A0X1","GXLX"};
+!   Twiss$Label["BX"]={"2B06O0X1","MGUUDXLX"};
+!   Twiss$Label["NX"]={"M0X1","GXLX"};
+!   Twiss$Label["EX"]={"H0X1","GXLX"};
+!   Twiss$Label["EPX"]={"HA0X1","GPXLX"};
+!   Twiss$Label["PEX"]={"H0XP1","GXL X"};
+!   Twiss$Label["PEPX"]={"HA0XP1","GPXL X"};
+!   Twiss$Label["DX"]={"DX","FL"};
+!   Twiss$Label["DPX"]={"DXA","FLP"};
+!   Twiss$Label["AY"]={"A0Y1","GXLX"};
+!   Twiss$Label["BY"]={"2B06O0Y1","MGUUDXLX"};
+!   Twiss$Label["NY"]={"M0Y1","GXLX"};
+!   Twiss$Label["EY"]={"H0Y1","GXLX"};
+!   Twiss$Label["EPY"]={"HA0Y1","GPXLX"};
+!   Twiss$Label["PEY"]={"H0YP1","GXL X"};
+!   Twiss$Label["PEPY"]={"HA0YP1","GPXL X"};
+!   Twiss$Label["DY"]={"DY","FL"};
+!   Twiss$Label["DPY"]={"DYA","FLP"};
+!   Twiss$Label["DZ"]={"DZ","FL"};
+!   Twiss$Label["R1"]={"R1","  "};
+!   Twiss$Label["R2"]={"R2","  "};
+!   Twiss$Label["R3"]={"R3","  "};
+!   Twiss$Label["R4"]={"R4","  "};
+!   Twiss$Label["DETR"]={"DETR"," LL "},
+!   ];
 
+If[DisplayFunction===Unevaluated[CanvasDrawer],
   Twiss$Unit$Label[Meter]="m";
   Twiss$Unit$Label[Kilometer]="km";
   Twiss$Unit$Label[Milimeter]="mm";
@@ -701,8 +705,7 @@ If[$DisplayFunction===Unevaluated[TopDrawer],
     {{l,u}=MakeSize$Label$Unit[x[5,-1]]},
     Twiss$Unit[x]=u;
     Twiss$Label[x]="`fs`n`d"//l//"`n"];
-
-  ];
+];
 
 Twiss$Label[_]:="";
 

--- a/Packages/Plots.n
+++ b/Packages/Plots.n
@@ -78,7 +78,7 @@ With[{CP$def={Scale->{Linear,Linear},
         ft=False;
         cla=Flatten[cl];
         cla=Join[cla,Table["",{Max[n*nc-Length[cla],0]}]];
-        tx=WindowScaled[If[$DisplayFunction===TopDrawer,0.8,2.3]];
+	tx=WindowScaled[If[$DisplayFunction===CanvasDrawer,2.3,0.8]];
         tis=0;
         ts=Max[Min[2,6/Max[1,StringLength/@cla],12/n/nc],0.9]*txs,
         cl===Automatic,
@@ -162,14 +162,17 @@ With[{CP$def={Scale->{Linear,Linear},
     g
     ]];
 
-With[{def={PlotStyle->ColumnPlot,Orientation->Vertical,
-  Bins:>Max[5,Min[100,Sqrt[Max[Length/@l]]]],
-  Dashing->{{1},{0.75,0.25},{0.4, 0.15},{0.2,0.1},{0.1,0.08},
-  {0.8,0.08, 0.08, 0.08},{0.4,0.08,0.08,0.08}},
-  PlotColor:>If[$DisplayFunction===TopDrawer,
-    {"black","red","blue","green","gray","magenta","cyan","yellow"},
-    {"black","tomato","dark slate blue","forest green","gray",
-      "magenta","cyan","yellow"}]}},
+With[{def={
+	PlotStyle->ColumnPlot,Orientation->Vertical,
+  	Bins:>Max[5,Min[100,Sqrt[Max[Length/@l]]]],
+  	Dashing->{{1},{0.75,0.25},{0.4, 0.15},{0.2,0.1},{0.1,0.08},
+	         {0.8,0.08, 0.08, 0.08},{0.4,0.08,0.08,0.08}},
+  	PlotColor:>If[$DisplayFunction===CanvasDrawerr,
+		{"black","tomato","dark slate blue","forest green","gray",
+		          "magenta","cyan","yellow"},
+      		{"black","red","blue","green","gray","magenta","cyan","yellow"}
+       		]
+      }},
 
   HistoPlot[l_,opt___]:=HistoPlot[{l},opt];
   HistoPlot[l:{{_,_},___},opt___]:=HistoPlot[{l},opt];

--- a/Packages/init.n
+++ b/Packages/init.n
@@ -611,10 +611,11 @@ AutoLoad[CaMonitor,PackagesDirectory//"CaSad2c.n"];
 AutoLoad[EPICSDB,PackagesDirectory//"CEPICSRecord.n"];
 
 $DisplayFunction=If[Environment["DISPLAY"]<=>"",CanvasDrawer,Identity,Identiy];
-Check[`f=OpenRead["!command -v tdr"];
-  Close[`f];
-  AutoLoad[TopDrawer,
-    PackagesDirectory//"TopDrawer.n"],];
+
+! Check[`f=OpenRead["!command -v tdr"];
+!   Close[`f];
+!   AutoLoad[TopDrawer,
+!     PackagesDirectory//"TopDrawer.n"],];
 
 AutoLoad[ListPlot,Plot,Show,Graphics,Rectangle,
   PackagesDirectory//"ListPlot.n"];

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# SAD
+This is a fork version of K.Oide's SAD repository.

--- a/src/geodrw.f
+++ b/src/geodrw.f
@@ -19,6 +19,14 @@ c       s.t.       x(beam)=x cos(t) - y sin(t)
       logical tmatch, over, exist, rght, other
       data keywrd /'RIGHT   ','LEFT    '/
       data window/2.,10.,1.,9./ parity /-1./
+      goto 9000
+ 9000 continue
+      call termes(lfno,
+     $     'A message from SAD/FFS: replace GEO command '//
+     $      'with GeometryPlot[].',
+     $  ' ')
+      return
+c$$$      
       alpha=getva(exist)
       if(.not.exist) then
         alpha=0.

--- a/src/ttdr.f
+++ b/src/ttdr.f
@@ -6,33 +6,36 @@
       character*12 autofg
       real*8 getva
       integer*4 system,lfno,ir,next,lfn
-      lfn=getva(exist)
-      if(exist)then
-        write(word,'(a,I2.2)')'ftn',lfn
-      else        
-        call peekwd(word,next)
-        if(word .eq. ' ')then
-          call termes(lfno,'Missing file in TDR',' ')
-          go to 9000
-        endif
-        call cssetp(next)
-      endif
-      call get_environment_variable('DISPLAY',display)
-      if(display .ne. ' ')then
-        ir=system('tdr -v X '//word(1:len_trim(word)))
-      else
-        ir=system('tdr '//word)
-      endif
-      if(ir .lt. 0)then
-        call termes(lfno,'Error in tdr, code =',
-     $       autofg(dble(ir),'S12.0'))
-        err=.true.
-      else
-        err=.false.
-      endif
-      return
+      goto 9000
+c$$$      lfn=getva(exist)
+c$$$      if(exist)then
+c$$$        write(word,'(a,I2.2)')'ftn',lfn
+c$$$      else        
+c$$$        call peekwd(word,next)
+c$$$        if(word .eq. ' ')then
+c$$$          call termes(lfno,'Missing file in TDR',' ')
+c$$$          go to 9000
+c$$$        endif
+c$$$        call cssetp(next)
+c$$$      endif
+c$$$      call get_environment_variable('DISPLAY',display)
+c$$$      if(display .ne. ' ')then
+c$$$        ir=system('tdr -v X '//word(1:len_trim(word)))
+c$$$      else
+c$$$        ir=system('tdr '//word)
+c$$$      endif
+c$$$      if(ir .lt. 0)then
+c$$$        call termes(lfno,'Error in tdr, code =',
+c$$$     $       autofg(dble(ir),'S12.0'))
+c$$$        err=.true.
+c$$$      else
+c$$$        err=.false.
+c$$$      endif
+c$$$      return
  9000 err=.true.
-      call termes(lfno,'Usage: TDR {filename|file_number}',' ')
+      call termes(lfno,
+     $  'A message from SAD: TDR command is now obsolete.',
+     $  ' ')
       return
       end
 


### PR DESCRIPTION
Some changes are made in files:

 Packages/CANVASDRAW.n
 Packages/HelpMessages.n
 Packages/OpticsPlot.n
 Packages/Plots.n
 Packages/init.n
 src/geodrw.f
 src/ttdr.f

to make the "tdr" command obsolete. GEO command also became obsolete, because it depends
on Topdrawer.
 
I can compile it on Ubuntu 18.04 without any problem.  And I also confirmed that tdr and GEO commands returns "obsoleted" error message.  These are all I have done for test.


Regards, 

Noboru