### PR TITLE
V1.2.5.2.1k64

### DIFF
--- a/src/.depend_c
+++ b/src/.depend_c
@@ -1,10 +1,12 @@
-autos_.o: autos_.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h sim/sad_f2c.h sim/TFCBK.h
-buildinfo_.o: buildinfo_.c buildinfo.h sim/sad_f2c.h
+CaSearch2.o: CaSearch2.c sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_tcltk.h
+CaSearch_.o: CaSearch_.c sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+DbStatic.o: DbStatic.c sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+PyConfig.o: PyConfig.c
+PySad.o: PySad.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+autos_.o: autos_.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h sim/TFCBK.h sim/sad_f2c.h
 buildinfo.o: buildinfo.c buildinfo.h feature.h
+buildinfo_.o: buildinfo_.c buildinfo.h sim/sad_f2c.h
 calc.o: calc.c sim/sad_f2c.h
-CaSearch2.o: CaSearch2.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_tcltk.h sim/TFCODE.h sim/TFSTK.h
-CaSearch_.o: CaSearch_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCODE.h sim/TFSTK.h
-DbStatic.o: DbStatic.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCODE.h sim/TFSTK.h
 eval1_.o: eval1_.c sim/sad_f2c.h
 feature.o: feature.c feature.h
 ft.o: ft.c ft.h
@@ -13,33 +15,31 @@ itfgetbuf_.o: itfgetbuf_.c sim/sad_f2c.h
 netSemaphore.o: netSemaphore.c netSemaphore.h
 nfgetm.o: nfgetm.c sim/sad_f2c.h
 psn.o: psn.c ft.h psn.h
-PyConfig.o: PyConfig.c
-PySad.o: PySad.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
 random_driver.o: random_driver.c feature.h random_driver.h
 random_plugin_sad.o: random_plugin_sad.c feature.h random_driver.h
 spch.o: spch.c
-tfBuildInfo_.o: tfBuildInfo_.c buildinfo.h feature.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfCrypt_.o: tfCrypt_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfDateTAI_.o: tfDateTAI_.c feature.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h timezone_table.h
-tfDynamicLink_.o: tfDynamicLink_.c feature.h sim/dynl.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfFeatureQ_.o: tfFeatureQ_.c feature.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfFileIO_.o: tfFileIO_.c feature.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfNetSemaphore_.o: tfNetSemaphore_.c netSemaphore.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCODE.h sim/TFSTK.h
-tfNetworkIO_.o: tfNetworkIO_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfProcess_.o: tfProcess_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_signal.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfPyInter_.o: tfPyInter_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCODE.h sim/TFSTK.h
-tfRandom_.o: tfRandom_.c feature.h random_driver.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfRenumberElement_.o: tfRenumberElement_.c feature.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFSTK.h
-tfTkInter_.o: tfTkInter_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_tcltk.h sim/sad_xlib.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tfXlib_.o: tfXlib_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_xlib.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-tgauss_.o: tgauss_.c random_driver.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFSTK.h
+tfBuildInfo_.o: tfBuildInfo_.c buildinfo.h feature.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfCrypt_.o: tfCrypt_.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfDateTAI_.o: tfDateTAI_.c feature.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h timezone_table.h
+tfDynamicLink_.o: tfDynamicLink_.c feature.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/dynl.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfFeatureQ_.o: tfFeatureQ_.c feature.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfFileIO_.o: tfFileIO_.c feature.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfNetSemaphore_.o: tfNetSemaphore_.c netSemaphore.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfNetworkIO_.o: tfNetworkIO_.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfProcess_.o: tfProcess_.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_signal.h
+tfPyInter_.o: tfPyInter_.c sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfRandom_.o: tfRandom_.c feature.h random_driver.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfRenumberElement_.o: tfRenumberElement_.c feature.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+tfTkInter_.o: tfTkInter_.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_tcltk.h sim/sad_xlib.h
+tfXlib_.o: tfXlib_.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_xlib.h
+tgauss_.o: tgauss_.c random_driver.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
 tspch_.o: tspch_.c
-utils.o: utils.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFSTK.h
-yylex_.o: yylex_.c calc.h sim/MACCBK.h sim/MACCODE.h sim/MACTTYP.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFSTK.h
-sim/dynl.o: sim/dynl.c sim/dynl.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
+utils.o: utils.c sim/TFCBK.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+yylex_.o: yylex_.c calc.h sim/MACCBK.h sim/MACCODE.h sim/MACTTYP.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
 sim/dynl-dl.o: sim/dynl-dl.c sim/dynl-dlsym.c.in sim/dynl.h
 sim/dynl-dummy.o: sim/dynl-dummy.c sim/dynl.h
-sim/fortran_io_.o: sim/fortran_io_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCODE.h sim/TFRBUF.h sim/TFSTK.h
+sim/dynl.o: sim/dynl.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/dynl.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+sim/fortran_io_.o: sim/fortran_io_.c sim/TFCODE.h sim/TFRBUF.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
 sim/fortran_math_acosh_.o: sim/fortran_math_acosh_.c sim/sad_f2c.h
 sim/fortran_math_asinh_.o: sim/fortran_math_asinh_.c sim/sad_f2c.h
 sim/fortran_math_atanh_.o: sim/fortran_math_atanh_.c sim/sad_f2c.h
@@ -48,55 +48,55 @@ sim/fseek_Dummy_.o: sim/fseek_Dummy_.c sim/sad_f2c.h
 sim/fseek_subroutine_.o: sim/fseek_subroutine_.c sim/sad_f2c.h
 sim/mapallocfile.o: sim/mapallocfile.c
 sim/maprwfile.o: sim/maprwfile.c
-sim/sad_api.o: sim/sad_api.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h
-sim/sad_functbl.o: sim/sad_functbl.c sim/dynl.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFSTK.h
+sim/sad_api.o: sim/sad_api.c sim/TFCBK.h sim/TFCODE.h sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
+sim/sad_functbl.o: sim/sad_functbl.c sim/TFSTK.h sim/dynl.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
 sim/sad_signal.o: sim/sad_signal.c sim/sad_f2c.h sim/sad_signal.h
-sim/sad_tcltk.o: sim/sad_tcltk.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_tcltk.h sim/TFSTK.h
+sim/sad_tcltk.o: sim/sad_tcltk.c sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/sad_tcltk.h
 sim/sad_xlib.o: sim/sad_xlib.c sim/sad_f2c.h sim/sad_xlib.h
 sim/unix_fortran_.o: sim/unix_fortran_.c sim/sad_f2c.h
-sim/unix_memory8_.o: sim/unix_memory8_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFSTK.h sim/unix_memory_.c
-sim/unix_memory_.o: sim/unix_memory_.c sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/TFSTK.h
+sim/unix_memory8_.o: sim/unix_memory8_.c sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h sim/unix_memory_.c
+sim/unix_memory_.o: sim/unix_memory_.c sim/TFSTK.h sim/sad_api.h sim/sad_f2c.h sim/sad_memory.h
 sim/unix_pointer_.o: sim/unix_pointer_.c sim/sad_f2c.h
 gdtoa/arithchk.o: gdtoa/arithchk.c
 gdtoa/dmisc.o: gdtoa/dmisc.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/dtoa.o: gdtoa/dtoa.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/g_Qfmt.o: gdtoa/g_Qfmt.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/g__fmt.o: gdtoa/g__fmt.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/g_ddfmt.o: gdtoa/g_ddfmt.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/g_dfmt.o: gdtoa/g_dfmt.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/g_dfmt.o: gdtoa/g_dfmt.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/g_ffmt.o: gdtoa/g_ffmt.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/g_xLfmt.o: gdtoa/g_xLfmt.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/g_xfmt.o: gdtoa/g_xfmt.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
 gdtoa/gdtoa.o: gdtoa/gdtoa.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/gethex.o: gdtoa/gethex.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/g_ffmt.o: gdtoa/g_ffmt.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/g__fmt.o: gdtoa/g__fmt.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/gmisc.o: gdtoa/gmisc.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/g_Qfmt.o: gdtoa/g_Qfmt.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/g_xfmt.o: gdtoa/g_xfmt.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/g_xLfmt.o: gdtoa/g_xLfmt.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/hd_init.o: gdtoa/hd_init.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/hexnan.o: gdtoa/hexnan.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/misc.o: gdtoa/misc.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/qnan.o: gdtoa/qnan.c
 gdtoa/smisc.o: gdtoa/smisc.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtod.o: gdtoa/strtod.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtodg.o: gdtoa/strtodg.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtodI.o: gdtoa/strtodI.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtodnrp.o: gdtoa/strtodnrp.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtof.o: gdtoa/strtof.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/strtoIQ.o: gdtoa/strtoIQ.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtoId.o: gdtoa/strtoId.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtoIdd.o: gdtoa/strtoIdd.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtoIf.o: gdtoa/strtoIf.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtoIg.o: gdtoa/strtoIg.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtoIQ.o: gdtoa/strtoIQ.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtoIx.o: gdtoa/strtoIx.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtoIxL.o: gdtoa/strtoIxL.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtopd.o: gdtoa/strtopd.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtopdd.o: gdtoa/strtopdd.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtopf.o: gdtoa/strtopf.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtopQ.o: gdtoa/strtopQ.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtopx.o: gdtoa/strtopx.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtopxL.o: gdtoa/strtopxL.c gdtoa/gdtoa_fltrnds.h gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/strtod.o: gdtoa/strtod.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/strtodI.o: gdtoa/strtodI.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/strtodg.o: gdtoa/strtodg.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/strtodnrp.o: gdtoa/strtodnrp.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
+gdtoa/strtof.o: gdtoa/strtof.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtopQ.o: gdtoa/strtopQ.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtopd.o: gdtoa/strtopd.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtopdd.o: gdtoa/strtopdd.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtopf.o: gdtoa/strtopf.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtopx.o: gdtoa/strtopx.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtopxL.o: gdtoa/strtopxL.c gdtoa/gdtoa.h gdtoa/gdtoa_fltrnds.h gdtoa/gdtoaimp.h
+gdtoa/strtorQ.o: gdtoa/strtorQ.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtord.o: gdtoa/strtord.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtordd.o: gdtoa/strtordd.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtorf.o: gdtoa/strtorf.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
-gdtoa/strtorQ.o: gdtoa/strtorQ.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtorx.o: gdtoa/strtorx.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/strtorxL.o: gdtoa/strtorxL.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h
 gdtoa/sum.o: gdtoa/sum.c gdtoa/gdtoa.h gdtoa/gdtoaimp.h

--- a/src/.depend_f
+++ b/src/.depend_f
@@ -1,15 +1,36 @@
-abbrev.o: abbrev.f
 ActGRA.o: ActGRA.f tfstk.o toplvl.o
 ActLie.o: ActLie.f tfstk.o toplvl.o
-actPlt.o: actPlt.f tfstk.o
 ActTra.o: ActTra.f tfstk.o toplvl.o
+CM24.o: CM24.f
+DM42.o: DM42.f
+FMUL2.o: FMUL2.f
+INTGRL.o: INTGRL.f initb1.o tbende.o tffs.o tfstk.o toplvl.o
+IPAK.o: IPAK.f toplvl.o
+IgetGL.o: IgetGL.f tfstk.o
+JNLPRM.o: JNLPRM.f toplvl.o
+LgetGL.o: LgetGL.f tfstk.o
+Lrdnum.o: Lrdnum.f tfstk.o toplvl.o
+MAIN.o: MAIN.f tfetok.o tfstk.o toplvl.o
+MINV2.o: MINV2.f
+MMUL2.o: MMUL2.f
+NewGRF.o: NewGRF.f tfstk.o toplvl.o
+R1INV.o: R1INV.f
+R2INV.o: R2INV.f
+SYMPS.o: SYMPS.f
+SYMTR2.o: SYMTR2.f
+UNITM2.o: UNITM2.f
+UNITM4.o: UNITM4.f
+ZEROM2.o: ZEROM2.f
+ZEROM4.o: ZEROM4.f
+ZEROV4.o: ZEROV4.f
+abbrev.o: abbrev.f
+actPlt.o: actPlt.f tfstk.o
 atof.o: atof.f toplvl.o
 autofg.o: autofg.f tfstk.o
 bb.o: bb.f initb1.o tfefun.o tfstk.o toplvl.o
 bbstrhl.o: bbstrhl.f initb1.o photons.o tfefun.o tffs.o tfstk.o toplvl.o
 bbtool.o: bbtool.f tfstk.o
 bint.o: bint.f tfstk.o
-CM24.o: CM24.f
 corfree.o: corfree.f inc/common.inc inc/coroper.inc tffs.o tfstk.o
 corinit.o: corinit.f inc/common.inc inc/coroper.inc tffs.o
 cputix.o: cputix.f toplvl.o
@@ -22,7 +43,6 @@ dAssgn.o: dAssgn.f tfstk.o toplvl.o
 datetime.o: datetime.f
 defflg.o: defflg.f tfstk.o
 defglb.o: defglb.f tfstk.o
-DM42.o: DM42.f
 doACT.o: doACT.f tfstk.o toplvl.o
 doelem.o: doelem.f tfstk.o toplvl.o
 doexpn.o: doexpn.f tfstk.o toplvl.o
@@ -36,8 +56,8 @@ dostop.o: dostop.f
 dotemp.o: dotemp.f tfstk.o toplvl.o
 drndsr.o: drndsr.f
 drwkwd.o: drwkwd.f tfstk.o
-dummyroutCA.o: dummyroutCA.f
 dummyrout.o: dummyrout.f
+dummyroutCA.o: dummyroutCA.f
 eigs33.o: eigs33.f tfstk.o
 elname.o: elname.f tffs.o tfstk.o
 errmsg.o: errmsg.f toplvl.o
@@ -46,7 +66,6 @@ fdate1.o: fdate1.f
 filaux.o: filaux.f tfstk.o toplvl.o
 filbuf.o: filbuf.f tfstk.o toplvl.o
 flmgr.o: flmgr.f tfstk.o toplvl.o
-FMUL2.o: FMUL2.f
 frand.o: frand.f tfstk.o
 gamma.o: gamma.f tfloor.o tfstk.o
 gaus3.o: gaus3.f
@@ -60,20 +79,17 @@ hg.o: hg.f gamma.o tfloor.o tfstk.o
 hsrch.o: hsrch.f tfstk.o toplvl.o
 icsmrk.o: icsmrk.f
 ielm.o: ielm.f tffs.o tfstk.o toplvl.o
-IgetGL.o: IgetGL.f tfstk.o
 inifil.o: inifil.f tfstk.o toplvl.o
 initb1.o: initb1.f tfstk.o toplvl.o
 initbl.o: initbl.f tfstk.o toplvl.o
 initdainterface.o: initdainterface.f tffs.o tfstk.o
-INTGRL.o: INTGRL.f initb1.o tbende.o tffs.o tfstk.o toplvl.o
-IPAK.o: IPAK.f toplvl.o
 italoc.o: italoc.f tfstk.o
 itfaloc.o: itfaloc.f tfstk.o toplvl.o
 itfcopy.o: itfcopy.f tfdset.o tfefun.o tfstk.o
 itfdepth.o: itfdepth.f itfpmat.o tfstk.o
 itfgetbuf.o: itfgetbuf.f
-itfgetbuf_f90.o: itfgetbuf_f90.f
 itfgetbuf_PPC.o: itfgetbuf_PPC.f
+itfgetbuf_f90.o: itfgetbuf_f90.f
 itfgeto.o: itfgeto.f tfstk.o toplvl.o
 itfmaloc.o: itfmaloc.f tfstk.o toplvl.o
 itfmessage.o: itfmessage.f tfeeval.o tfstk.o tfstrbuf.o toplvl.o
@@ -81,30 +97,24 @@ itfopenread.o: itfopenread.f toplvl.o
 itfopenread_G77.o: itfopenread_G77.f tfstk.o toplvl.o
 itfpmat.o: itfpmat.f tfeeval.o tfstk.o toplvl.o
 itopenbuf.o: itopenbuf.f toplvl.o
-JNLPRM.o: JNLPRM.f toplvl.o
-LgetGL.o: LgetGL.f tfstk.o
-Lrdnum.o: Lrdnum.f tfstk.o toplvl.o
 lread.o: lread.f tfstk.o toplvl.o
 lrflct.o: lrflct.f
 lstchk.o: lstchk.f
-MAIN.o: MAIN.f tfetok.o tfstk.o toplvl.o
 matrix.o: matrix.f tfstk.o
 mbmp.o: mbmp.f inc/common.inc inc/coroper.inc tffs.o tfstk.o
 mdpmax.o: mdpmax.f inc/common.inc
 metaer.o: metaer.f inc/common.inc tffs.o
-mfdel1.o: mfdel1.f tffs.o tfstk.o
 mfdel.o: mfdel.f tffs.o tfstk.o
+mfdel1.o: mfdel1.f tffs.o tfstk.o
 mfdir.o: mfdir.f tffs.o tfstk.o
 mfnst.o: mfnst.f inc/common.inc tffs.o
 mhogal.o: mhogal.f
 mhogan.o: mhogan.f
-MINV2.o: MINV2.f
 mkplst.o: mkplst.f tfstk.o toplvl.o
-MMUL2.o: MMUL2.f
 monel.o: monel.f
 monqu.o: monqu.f tffs.o tfstk.o
-mrecal1.o: mrecal1.f inc/common.inc tffs.o tfstk.o
 mrecal.o: mrecal.f tffs.o tfstk.o
+mrecal1.o: mrecal1.f inc/common.inc tffs.o tfstk.o
 mrmb.o: mrmb.f
 mrqcof.o: mrqcof.f
 mrqcov.o: mrqcov.f
@@ -114,18 +124,17 @@ msolv1.o: msolv1.f inc/common.inc tffs.o tfstk.o
 msolvg.o: msolvg.f tffs.o tfstk.o
 msort.o: msort.f
 msortn.o: msortn.f
+mstack.o: mstack.f tffs.o
 mstack1.o: mstack1.f tffs.o tfstk.o
 mstack2.o: mstack2.f inc/common.inc tffs.o tfstk.o
-mstack.o: mstack.f tffs.o
-mstat2.o: mstat2.f
 mstat.o: mstat.f
+mstat2.o: mstat2.f
 mstatp.o: mstatp.f
 mstor1.o: mstor1.f inc/common.inc tffs.o tfstk.o
 mstore.o: mstore.f tffs.o tfstk.o
 mwght.o: mwght.f inc/common.inc tffs.o
 nalign.o: nalign.f tffs.o tfstk.o
 ndelw.o: ndelw.f tffs.o tfstk.o
-NewGRF.o: NewGRF.f tfstk.o toplvl.o
 nlfit.o: nlfit.f
 openP.o: openP.f toplvl.o
 over.o: over.f
@@ -140,14 +149,14 @@ pgflag.o: pgflag.f tffs.o tfstk.o
 pgmast.o: pgmast.f tffs.o tfstk.o
 pgrmat.o: pgrmat.f initb1.o tffs.o tfstk.o
 pgsolvcond.o: pgsolvcond.f itfmaloc.o tfstk.o
-phdrwa.o: phdrwa.f tfstk.o
 phdrw.o: phdrw.f tfstk.o toplvl.o
+phdrwa.o: phdrwa.f tfstk.o
 photons.o: photons.f gamma.o tchge.o tffs.o tfloor.o tfstk.o tgrot.o toplvl.o
 phsrot.o: phsrot.f initb1.o tffs.o toplvl.o
 pinner.o: pinner.f
 pkill.o: pkill.f inc/common.inc tffs.o
-pmbdata1.o: pmbdata1.f tffs.o
 pmbdata.o: pmbdata.f tffs.o tfstk.o
+pmbdata1.o: pmbdata1.f tffs.o
 pmbdrw.o: pmbdrw.f
 pmbump.o: pmbump.f inc/common.inc tffs.o tfstk.o
 pmeas.o: pmeas.f tffs.o tfstk.o
@@ -156,23 +165,23 @@ pmovi.o: pmovi.f
 polpar.o: polpar.f tffs.o tfstk.o
 ppair.o: ppair.f tffs.o tfstk.o
 pqcell.o: pqcell.f tffs.o
+prSad.o: prSad.f tfstk.o toplvl.o
 preabuf.o: preabuf.f
 preadmon.o: preadmon.f inc/common.inc tffs.o toplvl.o
 preadstr.o: preadstr.f inc/common.inc inc/coroper.inc tffs.o tfstk.o toplvl.o
 prelem.o: prelem.f tfstk.o
 prelm0.o: prelm0.f tfstk.o toplvl.o
 prexln.o: prexln.f tfstk.o toplvl.o
-prkick1.o: prkick1.f inc/common.inc tffs.o tfstk.o
 prkick.o: prkick.f tffs.o tfstk.o
+prkick1.o: prkick1.f inc/common.inc tffs.o tfstk.o
 prkwdv.o: prkwdv.f tfstk.o toplvl.o
 prline.o: prline.f tfstk.o toplvl.o
-prnflg.o: prnflg.f tfstk.o toplvl.o
 prnGlb.o: prnGlb.f tfstk.o toplvl.o
-prSad.o: prSad.f tfstk.o toplvl.o
+prnflg.o: prnflg.f tfstk.o toplvl.o
+pstati.o: pstati.f tffs.o tfstk.o toplvl.o
 pstati1.o: pstati1.f inc/common.inc tffs.o tfstk.o
 pstati2.o: pstati2.f
-pstati3.o: pstati3.f inc/TFMACRO1.inc inc/TFMACRO.inc tffs.o tfstk.o
-pstati.o: pstati.f tffs.o tfstk.o toplvl.o
+pstati3.o: pstati3.f inc/TFMACRO.inc inc/TFMACRO1.inc tffs.o tfstk.o
 psub.o: psub.f
 ptimes.o: ptimes.f
 ptol.o: ptol.f inc/common.inc tffs.o tfstk.o
@@ -181,10 +190,10 @@ ptrim.o: ptrim.f inc/common.inc tffs.o tfstk.o
 pundo.o: pundo.f inc/common.inc tffs.o tfstk.o
 push.o: push.f
 putsti.o: putsti.f tffs.o tfstk.o
+pvbump.o: pvbump.f inc/common.inc tffs.o tfstk.o
 pvbump1.o: pvbump1.f
 pvbump2.o: pvbump2.f inc/common.inc tffs.o tfstk.o
 pvbump3.o: pvbump3.f tffs.o tfstk.o
-pvbump.o: pvbump.f inc/common.inc tffs.o tfstk.o
 pvert.o: pvert.f tffs.o tfstk.o
 pwmatq.o: pwmatq.f tffs.o tfstk.o
 pwrite.o: pwrite.f tffs.o tfstk.o
@@ -211,8 +220,6 @@ qquad.o: qquad.f
 qtent.o: qtent.f tffs.o tfstk.o
 qthin.o: qthin.f
 qtwiss.o: qtwiss.f initb1.o tffs.o tfstk.o tgrot.o toplvl.o
-R1INV.o: R1INV.f
-R2INV.o: R2INV.f
 rdexpr.o: rdexpr.f tfstk.o toplvl.o
 rdkwdl.o: rdkwdl.f tfstk.o toplvl.o
 rdterm.o: rdterm.f tfstk.o toplvl.o
@@ -226,29 +233,27 @@ spkick.o: spkick.f tdrift.o tffs.o tfloor.o tfstk.o toplvl.o
 spline.o: spline.f itfmaloc.o tfreplace.o tfstk.o
 sprexl.o: sprexl.f tfstk.o toplvl.o
 sprlin.o: sprlin.f tfstk.o toplvl.o
-SYMPS.o: SYMPS.f
-SYMTR2.o: SYMTR2.f
 synradcl.o: synradcl.f toplvl.o
 talign.o: talign.f tffs.o tfstk.o
 tapert.o: tapert.f initb1.o tffs.o tfstk.o toplvl.o tturn.o
 tbal.o: tbal.f
 tbbbrem.o: tbbbrem.f tfstk.o
 tbdecoup.o: tbdecoup.f
-tbende.o: tbende.f photons.o tbend.o tchge.o tffs.o tfloor.o tfstk.o toplvl.o
 tbend.o: tbend.f photons.o tdrift.o tffs.o tfloor.o tfstk.o toplvl.o
+tbende.o: tbende.f photons.o tbend.o tchge.o tffs.o tfloor.o tfstk.o toplvl.o
 tbendi.o: tbendi.f photons.o tbend.o tffs.o tfstk.o toplvl.o
 tbfrie.o: tbfrie.f tffs.o tfloor.o tfstk.o toplvl.o
 tbrad.o: tbrad.f tfstk.o toplvl.o
-tcave.o: tcave.f tchge.o tffs.o tfloor.o tfstk.o toplvl.o
 tcav.o: tcav.f inc/TENT.inc inc/TEXIT.inc tffs.o tfloor.o toplvl.o txwake.o
+tcave.o: tcave.f tchge.o tffs.o tfloor.o tfstk.o toplvl.o
 tceigen.o: tceigen.f
 tcftr.o: tcftr.f tfstk.o
 tchge.o: tchge.f tffs.o tfloor.o tfstk.o toplvl.o
 tcod.o: tcod.f tffs.o tfloor.o tfstk.o toplvl.o
 tconv.o: tconv.f tfloor.o toplvl.o
 tconvm.o: tconvm.f tfloor.o toplvl.o
-tcoorde.o: tcoorde.f tffs.o tfloor.o toplvl.o
 tcoord.o: tcoord.f tfloor.o toplvl.o
+tcoorde.o: tcoorde.f tffs.o tfloor.o toplvl.o
 tcorr.o: tcorr.f tffs.o tfstk.o toplvl.o
 tcsvdm.o: tcsvdm.f tfloor.o tfstk.o
 tday.o: tday.f
@@ -273,6 +278,7 @@ temits.o: temits.f tcod.o tffs.o tfstk.o tgfun.o toplvl.o
 temp.o: temp.f tfstk.o toplvl.o
 termes.o: termes.f tffs.o tfstk.o
 terror.o: terror.f tffs.o tfstk.o
+tfTclArg.o: tfTclArg.f tfconvstr.o tfstk.o tfstrbuf.o
 tfadjst.o: tfadjst.f tffs.o tfstk.o
 tfaprt.o: tfaprt.f tffs.o tfstk.o
 tfattr.o: tfattr.f tffs.o tfstk.o
@@ -294,28 +300,28 @@ tfearray.o: tfearray.f
 tfecmplx.o: tfecmplx.f tfstk.o
 tfeeval.o: tfeeval.f tffuns.o tfstk.o toplvl.o
 tfeexpr.o: tfeexpr.f tfefun.o tfstk.o
-tfefun1.o: tfefun1.f tffsa.o tffs.o tfstk.o
+tfefun.o: tfefun.f gamma.o tfconvstr.o tfdot.o tfdset.o tfecmplx.o tfeeval.o tfeval1.o tffindroot.o tffuns.o tfloor.o tfmodule.o tfpart.o tfreplace.o tfsameq.o tfsolvemember.o tfstk.o tftable.o tftake.o toplvl.o
+tfefun1.o: tfefun1.f tffs.o tffsa.o tfstk.o
 tfefun2.o: tfefun2.f tfstk.o
 tfefun3ep.o: tfefun3ep.f tfeeval.o tfefun.o tfstk.o
-tfefun.o: tfefun.f gamma.o tfconvstr.o tfdot.o tfdset.o tfecmplx.o tfeeval.o tfeval1.o tffindroot.o tffuns.o tfloor.o tfmodule.o tfpart.o tfreplace.o tfsameq.o tfsolvemember.o tfstk.o tftable.o tftake.o toplvl.o
 tfematrix.o: tfematrix.f tfstk.o
 tfemit.o: tfemit.f tffs.o tfstk.o toplvl.o
 tfepicsconstatcb.o: tfepicsconstatcb.f tfeeval.o tfsolvemember.o tfstk.o
 tfestk.o: tfestk.f itfpmat.o tfeeval.o tfefun.o tfmodule.o tfsolvemember.o tfstk.o toplvl.o
 tfetok.o: tfetok.f tfconvstr.o tffs.o tfstk.o tfstrbuf.o toplvl.o
-tfeval1.o: tfeval1.f tfecmplx.o tfeeval.o tfstk.o
 tfeval.o: tfeval.f tfeeval.o tfstk.o toplvl.o
-tffamsetup.o: tffamsetup.f tfeeval.o tffscalc.o tffs.o tfstk.o
-tffile.o: tffile.f tffsa.o tffs.o tfstk.o toplvl.o
+tfeval1.o: tfeval1.f tfecmplx.o tfeeval.o tfstk.o
+tffamsetup.o: tffamsetup.f tfeeval.o tffs.o tffscalc.o tfstk.o
+tffile.o: tffile.f tffs.o tffsa.o tfstk.o toplvl.o
 tffindroot.o: tffindroot.f gamma.o itfmaloc.o tfeeval.o tfmodule.o tfpart.o tfreplace.o tfsameq.o tfstk.o
-tffsa.o: tffsa.f INTGRL.o tfeeval.o tffscalc.o tffsmatch.o tffs.o tfmodule.o tfstk.o tgrot.o toplvl.o
-tffscalc.o: tffscalc.f qcell.o qdcell.o tfeeval.o tffs.o tfloor.o tfstk.o toplvl.o
 tffs.o: tffs.f initb1.o tfefun.o tfloor.o tfstk.o toplvl.o
+tffsa.o: tffsa.f INTGRL.o tfeeval.o tffs.o tffscalc.o tffsmatch.o tfmodule.o tfstk.o tgrot.o toplvl.o
+tffscalc.o: tffscalc.f qcell.o qdcell.o tfeeval.o tffs.o tfloor.o tfstk.o toplvl.o
 tffsfreefix.o: tffsfreefix.f tffs.o tfstk.o toplvl.o
-tffsmatch.o: tffsmatch.f initb1.o qcell.o qdcell.o tfeeval.o tffindroot.o tffscalc.o tffs.o tfstk.o toplvl.o
-tffswake.o: tffswake.f itfmaloc.o qcell.o tfeeval.o tffscalc.o tffs.o tfstk.o
+tffsmatch.o: tffsmatch.f initb1.o qcell.o qdcell.o tfeeval.o tffindroot.o tffs.o tffscalc.o tfstk.o toplvl.o
+tffswake.o: tffswake.f itfmaloc.o qcell.o tfeeval.o tffs.o tffscalc.o tfstk.o
 tffuns.o: tffuns.f tfstk.o
-tfgeo.o: tfgeo.f initb1.o photons.o tffsa.o tffs.o tfloor.o tfstk.o tgrot.o toplvl.o
+tfgeo.o: tfgeo.f initb1.o photons.o tffs.o tffsa.o tfloor.o tfstk.o tgrot.o toplvl.o
 tfgeti.o: tfgeti.f
 tfgetm.o: tfgetm.f tffs.o tfstk.o
 tfgetr.o: tfgetr.f
@@ -337,8 +343,8 @@ tfmodule.o: tfmodule.f tfdset.o tfeeval.o tfreplace.o tfstk.o
 tfojit.o: tfojit.f tffs.o
 tfoptics.o: tfoptics.f qcell.o tffs.o tfstk.o toplvl.o
 tfpart.o: tfpart.f tfeeval.o tfstk.o
-tfprinta.o: tfprinta.f tfeeval.o tfstk.o tfstrbuf.o toplvl.o
 tfprint.o: tfprint.f tfdset.o tfeeval.o tfefun.o tffs.o tfsolvemember.o tfstk.o toplvl.o
+tfprinta.o: tfprinta.f tfeeval.o tfstk.o tfstrbuf.o toplvl.o
 tfrbuf.o: tfrbuf.f tfstk.o toplvl.o
 tfreadbuf.o: tfreadbuf.f
 tfrej.o: tfrej.f tffs.o tfstk.o
@@ -358,7 +364,6 @@ tfstk.o: tfstk.f
 tfstrbuf.o: tfstrbuf.f tfstk.o
 tftable.o: tftable.f tfeeval.o tfmodule.o tfstk.o
 tftake.o: tftake.f tfecmplx.o tfeeval.o tfstk.o
-tfTclArg.o: tfTclArg.f tfconvstr.o tfstk.o tfstrbuf.o
 tftmat.o: tftmat.f tffs.o tfstk.o
 tftrack.o: tftrack.f itfmaloc.o photons.o tffs.o tfloor.o tfstk.o toplvl.o
 tftrad.o: tftrad.f tfstk.o
@@ -377,14 +382,14 @@ tgfun.o: tgfun.f tffs.o tfstk.o tgrot.o
 tgrot.o: tgrot.f tffs.o tfloor.o
 thess.o: thess.f
 tinitr.o: tinitr.f
-tinse.o: tinse.f tffs.o toplvl.o
 tins.o: tins.f toplvl.o
+tinse.o: tinse.f tffs.o toplvl.o
 tintrb.o: tintrb.f gamma.o temit.o tffs.o tfloor.o tfstk.o toplvl.o
 title.o: title.f toplvl.o
 tlinit.o: tlinit.f itfmaloc.o tfstk.o toplvl.o
 tltrm.o: tltrm.f tffs.o tfstk.o toplvl.o
-tluma.o: tluma.f toplvl.o
 tlum.o: tlum.f tfstk.o
+tluma.o: tluma.f toplvl.o
 tmap.o: tmap.f tffs.o
 tmast.o: tmast.f tffs.o tfstk.o
 tmatch.o: tmatch.f tfstk.o
@@ -393,31 +398,31 @@ tmulbs.o: tmulbs.f tffs.o tfstk.o toplvl.o
 tmuld.o: tmuld.f
 tmulta.o: tmulta.f photons.o tbend.o tchge.o tffs.o tfloor.o tfstk.o toplvl.o
 tmulte.o: tmulte.f initb1.o photons.o tffs.o tfloor.o tfstk.o toplvl.o tsol.o
-tmulti.o: tmulti.f initb1.o photons.o tffs.o tfloor.o tfstk.o toplvl.o tsol.o tsolque.o
+tmulti.o: tmulti.f initb1.o photons.o tffs.o tfloor.o tfstk.o toplvl.o tsol.o tsolque.o txwake.o
 tmultr.o: tmultr.f
 tnorm.o: tnorm.f
 toplvl.o: toplvl.f gamma.o tfstk.o
 tpara.o: tpara.f
 tphplt.o: tphplt.f
 tprmpt.o: tprmpt.f tffs.o tfstk.o
-tputbs.o: tputbs.f
 tput.o: tput.f
+tputbs.o: tputbs.f
 tqente.o: tqente.f tdrift.o tffs.o tfloor.o
 tqfrie.o: tqfrie.f tffs.o tfstk.o toplvl.o
 tqlfre.o: tqlfre.f tffs.o toplvl.o
-tqrad.o: tqrad.f inc/TENT.inc inc/TEXIT.inc tffs.o toplvl.o
 tqr.o: tqr.f tfstk.o
-tquade.o: tquade.f photons.o tffs.o tfstk.o toplvl.o tsol.o
+tqrad.o: tqrad.f inc/TENT.inc inc/TEXIT.inc tffs.o toplvl.o
 tquad.o: tquad.f inc/TENT.inc inc/TEXIT.inc initb1.o photons.o tdrift.o tffs.o tfloor.o tfstk.o toplvl.o tsol.o
+tquade.o: tquade.f photons.o tffs.o tfstk.o toplvl.o tsol.o
 tquads.o: tquads.f photons.o tffs.o tfloor.o tfstk.o toplvl.o tsol.o
 tquase.o: tquase.f photons.o tffs.o tfstk.o toplvl.o tsol.o
+track.o: track.f temit.o tffs.o tffsa.o tfstk.o toplvl.o
 tracka.o: tracka.f tfeeval.o tffs.o tfstk.o toplvl.o
-trackb.o: trackb.f tffsa.o tffs.o tfstk.o
+trackb.o: trackb.f tffs.o tffsa.o tfstk.o
 trackd.o: trackd.f tffs.o tfstk.o tftrack.o toplvl.o
-tracke.o: tracke.f tffsa.o tffs.o tfstk.o
-track.o: track.f temit.o tffsa.o tffs.o tfstk.o toplvl.o
-trade.o: trade.f tffs.o tfloor.o toplvl.o
+tracke.o: tracke.f tffs.o tffsa.o tfstk.o
 trad.o: trad.f photons.o tffs.o tfloor.o tfstk.o toplvl.o
+trade.o: trade.f tffs.o tfloor.o toplvl.o
 trcoda.o: trcoda.f tffs.o tfstk.o
 trotg.o: trotg.f
 tscale.o: tscale.f tffs.o
@@ -427,10 +432,10 @@ tserad.o: tserad.f initb1.o tffs.o tfstk.o toplvl.o
 tsgeo.o: tsgeo.f initb1.o tffs.o tfloor.o tfstk.o tgrot.o
 tshow.o: tshow.f tffs.o tfstk.o
 tsmear.o: tsmear.f toplvl.o
-tsole.o: tsole.f initb1.o photons.o tffs.o tfstk.o toplvl.o
 tsol.o: tsol.f initb1.o photons.o tdrift.o tffs.o tfloor.o tfstk.o toplvl.o txwake.o
-tsolque.o: tsolque.f photons.o tffs.o tfloor.o tfstk.o toplvl.o
+tsole.o: tsole.f initb1.o photons.o tffs.o tfstk.o toplvl.o
 tsolqu.o: tsolqu.f photons.o tffs.o tfloor.o tsolque.o
+tsolque.o: tsolque.f photons.o tffs.o tfloor.o tfstk.o toplvl.o
 tsolvg.o: tsolvg.f tfloor.o
 tsolvm.o: tsolvm.f
 tspac.o: tspac.f tfstk.o toplvl.o
@@ -440,14 +445,14 @@ tsteee.o: tsteee.f photons.o tbend.o tchge.o tffs.o tfloor.o toplvl.o
 tsteer.o: tsteer.f inc/TENT.inc inc/TEXIT.inc photons.o tbend.o tdrift.o tffs.o tfloor.o toplvl.o
 tstrad.o: tstrad.f inc/TENT.inc inc/TEXIT.inc tffs.o toplvl.o
 tsvdm.o: tsvdm.f tfloor.o tfstk.o
-ttcave.o: ttcave.f tchge.o tffs.o toplvl.o
 ttcav.o: ttcav.f inc/TENT.inc inc/TEXIT.inc photons.o tdrift.o tffs.o tfloor.o toplvl.o
+ttcave.o: ttcave.f tchge.o tffs.o toplvl.o
 ttdr.o: ttdr.f toplvl.o
 tthine.o: tthine.f tchge.o tffs.o toplvl.o
 ttinit.o: ttinit.f initb1.o tffs.o tfstk.o toplvl.o
 ttstat.o: ttstat.f tffs.o tfstk.o
-tturne.o: tturne.f initb1.o itfmaloc.o temit.o tffs.o tfloor.o tfstk.o toplvl.o
 tturn.o: tturn.f initb1.o photons.o tdrift.o tffs.o tfloor.o tfstk.o toplvl.o txwake.o
+tturne.o: tturne.f initb1.o itfmaloc.o temit.o tffs.o tfloor.o tfstk.o toplvl.o
 tvcorr.o: tvcorr.f tfstk.o
 twbuf.o: twbuf.f tffs.o
 twelm.o: twelm.f tffs.o
@@ -455,10 +460,8 @@ twinil.o: twinil.f
 twinit.o: twinit.f
 twsdrw.o: twsdrw.f tffs.o tfstk.o
 txcalc.o: txcalc.f tffs.o tfstk.o
-txwake.o: txwake.f inc/TENT.inc inc/TEXIT.inc tffs.o tfstk.o
+txwake.o: txwake.f inc/TENT.inc inc/TEXIT.inc initb1.o tffs.o tfstk.o
 undulator.o: undulator.f inc/TENT.inc inc/TEXIT.inc tffs.o toplvl.o
-UNITM2.o: UNITM2.f
-UNITM4.o: UNITM4.f
 wfbin.o: wfbin.f
 wfres.o: wfres.f
 wiord.o: wiord.f
@@ -467,9 +470,6 @@ wjfit.o: wjfit.f tfstk.o
 wtune.o: wtune.f
 wtunem.o: wtunem.f
 xsin.o: xsin.f
-ZEROM2.o: ZEROM2.f
-ZEROM4.o: ZEROM4.f
-ZEROV4.o: ZEROV4.f
 ztan.o: ztan.f
 sim/fortran_io.o: sim/fortran_io.f
 sim/fseek_subroutine.o: sim/fseek_subroutine.f

--- a/src/MAIN.f
+++ b/src/MAIN.f
@@ -1,8 +1,8 @@
       module version
         character*19, parameter ::
 c                     /'1234567890123456789'/
-     $     versionid  ='1.2.5.2k64         ',
-     $     versiondate='10/13/2022 00:00:00'
+     $     versionid  ='1.2.5.2.1k64       ',
+     $     versiondate='10/17/2022 00:00:00'
 
         character*25 builtdate
         character*30 startdat

--- a/src/txwake.f
+++ b/src/txwake.f
@@ -214,4 +214,32 @@ c          endif
         return
         end subroutine
 
+        logical*4 function ewak(l,nextwake,lele,cmp,nwak,nwak1) result(a)
+        use sad_main
+        use maccode
+        use kyparam
+        implicit none
+        integer*4 ,intent(in):: l,nextwake,lele,nwak
+        type (sad_comp),intent(in):: cmp
+        integer*4 ,intent(out):: nwak1
+        if(l /= nextwake .or. nwak == 0)then
+          a=.false.
+          nwak1=0
+        elseif(lele == icCAVI)then
+          a=.false.
+          nwak1=nwak
+        elseif(lele == icMULT)then
+          nwak1=nwak
+          if(cmp%value(ky_VOLT_MULT)+cmp%value(ky_DVOLT_MULT) == 0.d0)then
+            a=.true.
+          else
+            a=.false.
+          endif
+        else
+          a=.true.
+          nwak1=nwak
+        endif
+        return
+        end function
+
       end module


### PR DESCRIPTION
Fixes:

1. Tracking within SOL with MULT was wrong since the previous version, 1.2.5.2 (Oct. 13, 2022). It was intended to treat wakes in MULT in the same way as CAVI, but the mod in SOL had a mistake to break all tracking through MULT within SOL.