### PR TITLE
V1.2.5.3k64 many fixes

### DIFF
--- a/src/MAIN.f
+++ b/src/MAIN.f
@@ -1,8 +1,8 @@
       module version
         character*19, parameter ::
 c                     /'1234567890123456789'/
-     $     versionid  ='1.2.5.3k64         ',
-     $     versiondate='11/1/2022 00:00:00 '
+     $     versionid  ='1.2.5.4k64         ',
+     $     versiondate='11/30/2022 00:00:00'
 
         character*25 builtdate
         character*30 startdat

--- a/src/qcell.f
+++ b/src/qcell.f
@@ -4,6 +4,8 @@
       use ffs_pointer
       use ffs_fit, only:ffs_stat
       use tffitcode
+      integer*4 ,parameter ::nmmax=4
+      integer*4 nmes
 
       contains
       subroutine qcell(idp,optstat,fam)
@@ -42,7 +44,7 @@
      $     dpsix,dpsiy,cosx,sinx,cosy,siny,
      $     x11,x22,y11,y22
       integer*4 ie1,l,nm,lx
-      logical*4 stab,codfnd,pri,nanq
+      logical*4 stab,codfnd,nanq
       real*8 trans(4,5),cod(6),
      $     tm11,tm12,tm13,tm14,tm15,
      $     tm21,tm22,tm23,tm24,tm25,
@@ -61,18 +63,18 @@
         call qcell6d(fbound,idp,optstat,lfno)
         return
       endif
-      pri=.false.
       if(cell)then
         codfnd=fam
         cod=twiss(fbound%lb,idp,mfitdx:mfitddp)
         call qcod(idp,fbound,trans,cod,codfnd,optstat%over)
         if(optstat%over)then
-          if(lfno > 0)then
+          if(lfno > 0 .and. nmes < nmmax)then
+            nmes=nmes+1
             if(.not. codfnd)then
               write(lfno,*)
-     $             '*****qcod---> Overflow & closed orbit not found'
+     $             '*****qcod---> Overflow & closed orbit not found ',nmes
             else
-              write(lfno,*)'*****qcod---> Overflow'
+              write(lfno,*)'*****qcod---> Overflow ',nmes
             endif
           endif
           optstat%stabx=.false.
@@ -82,9 +84,9 @@
           if(orbitcal)then
             twiss(fbound%lb,idp,mfitdx:mfitddp)=cod
           endif
-        elseif(lfno > 0)then
-          write(lfno,*)'*****qcod---> Closed orbit not found'
-          pri=.true.
+        elseif(lfno > 0 .and. nmes < nmmax)then
+          nmes=nmes+1
+          write(lfno,*)'*****qcod---> Closed orbit not found ',nmes
         endif
         if(.not. calopt)then
           if(codfnd)then
@@ -296,9 +298,9 @@ c     (Note) Disperdion is defined in 2*2 world
       endif
       ie1=fbound%le
       if(optstat%over)then
-        if(lfno > 0)then
+        if(lfno > 0 .and. nmes < nmmax)then
+          nmes=nmes+1
           write(lfno,'(a,2i8,1pg15.7)')'***qtwiss---> Overflow (fb) ',fbound%lb,fbound%le,fbound%fb
-          pri=.true.
         endif
         optstat%stabx=.false.
         optstat%staby=.false.
@@ -308,9 +310,9 @@ c     (Note) Disperdion is defined in 2*2 world
         call qtwissfrac1(ftwiss,trans,cod,idp,fbound%le,0.d0,fbound%fe,
      $       .false.,.true.,optstat%over)
         if(optstat%over)then
-          if(lfno > 0)then
+          if(lfno > 0 .and. nmes < nmmax)then
+            nmes=nmes+1
             write(lfno,'(a,2i8,1pg15.7)')'***qtwiss---> Overflow (fe) ',fbound%lb,fbound%le,fbound%fe
-            pri=.true.
           endif
           optstat%stabx=.false.
           optstat%staby=.false.
@@ -403,9 +405,6 @@ c     (Note) Disperdion is defined in 2*2 world
         optstat%staby=optstat%staby .and. stab .and. (codfnd .or. fam)
       endif
       optstat%tracez=0.d0
-c      if(pri)then
-c        lfno=0
-c      endif
       return
       end
 

--- a/src/qtwiss.f
+++ b/src/qtwiss.f
@@ -819,7 +819,7 @@ c      write(*,*)'qtrans ',la,lb,la1,lb1,fra,frb
       implicit none
       type (ffs_bound) fbound
       real*8 conv,cx,sx,ax,bx,cy,sy,ay,by,r0,dcod(6)
-      integer*4 , parameter :: itmax=30
+      integer*4 , parameter :: itmax=10
       real*8 , parameter :: conv0=1.d-19,conv1=1.d-10,
      $     factmin=1.d-3,orbmax=1.d10,trmax=1.d10
       integer*4 ,intent(in)::  idp

--- a/src/tbend.f
+++ b/src/tbend.f
@@ -563,7 +563,7 @@ c     $       /(pz3+ph2*cosp2)/(pz2+ph2*cosp1)
         elseif(phib == 0.d0)then
           call tquad(np,x,px,y,py,z,g,dv,sx,sy,sz,al,ak,0.d0,
      1         dx,dy,theta+dtheta,theta+dtheta,krad,.true.,
-     1         fringe,0.d0,0.d0,0,eps,.true.)
+     1         fringe,0.d0,0.d0,0.d0,0.d0,0,eps,.true.)
         else
           akm=0.d0
           akm(0)=ak0
@@ -575,7 +575,7 @@ c     $       /(pz3+ph2*cosp2)/(pz2+ph2*cosp1)
           call tmulti(np,x,px,y,py,z,g,dv,sx,sy,sz,
      $         al,akm,akr0,0.d0,0.d0,0.d0,0.d0,
      $         dx,dy,0.d0,0.d0,0.d0,theta+dtheta,0.d0,
-     $         theta2,
+     $         theta2,alg,phig,
      $         eps,krad,fringe,
      $         0.d0,0.d0,0.d0,0.d0,
      $         mfring,fb10,fb20,dofr,
@@ -599,8 +599,7 @@ c     $     y(1)-y(2),py(1)-py(2),z(1)-z(2),g(1)-g(2)
         call tbdrift(np,x,px,y,py,z,dv,sx,sz,al,phi0)
         go to 9000
       elseif(al == 0.d0)then
-        call tbthin(np,x,px,y,py,z,g,sx,sy,sz,phib,phi0,dx,dy,
-     1              dtheta,cost,sint,dchi2)
+        call tbthin(np,x,px,y,py,z,g,sx,sy,sz,phib,phi0)
         go to 9000
       endif
       rhob=al/phib
@@ -718,26 +717,15 @@ c      endif
       return
       end
 
-      subroutine tbthin(np,x,px,y,py,z,g,sx,sy,sz,phib,phi0,dx,dy,
-     1                 dtheta,cost,sint,dchi2)
-      use tbendcom, only:tbrot,tbshift
+      subroutine tbthin(np,x,px,y,py,z,g,sx,sy,sz,phib,phi0)
       implicit none
       integer*4 ,intent(in):: np
       integer*4 i
-      real*8 ,intent(in):: phib,phi0,dx,dy,cost,sint,dtheta,dchi2
-      real*8 ,intent(inout):: x(np),px(np),y(np),py(np),z(np),
-     $     g(np),sx(np),sy(np),sz(np)
-      call tbshift(np,x,px,y,py,z,dx,dy,phi0,cost,sint,.true.)
-      if(dtheta .ne. 0.d0 .or. dchi2 /= 0.d0)then
-        call tbrot(np,x,px,y,py,z,sx,sy,sz,0.d0,.5d0*phi0,dtheta,dchi2,.true.)
-      endif
+      real*8 ,intent(in):: phib,phi0
+      real*8 ,intent(inout):: x(np),px(np),y(np),py(np),z(np),g(np),sx(np),sy(np),sz(np)
       do concurrent (i=1:np)
         px(i)=px(i)+phi0-phib/(1.d0+g(i))
         z(i)=z(i)-x(i)*phi0
       enddo
-      if(dtheta .ne. 0.d0 .or. dchi2 /= 0.d0)then
-        call tbrot(np,x,px,y,py,z,sx,sy,sz,0.d0,-.5d0*phi0,dtheta,dchi2,.false.)
-      endif
-      call tbshift(np,x,px,y,py,z,-dx,-dy,-phi0,cost,-sint,.false.)
       return
       end

--- a/src/temit.f
+++ b/src/temit.f
@@ -262,6 +262,7 @@ c          endif
       complex*16 dceig(6),cc(6),ceig(6)
       logical*4 ,intent(in):: calem
       logical*4 ,intent(out):: stab
+c      write(*,'(a,1p4G15.7)')'tecalc-0 ',beam(1),beam(3),beam(6),beam(10)
       rx=trans(:,1:6)
       if(.not. rfsw)then
         rx(6,1:5)=0.d0
@@ -285,9 +286,6 @@ c          endif
         r=tsymp(r)
         ri=tinv6(r)
       endif
-c      tw=tfetwiss(ri,codin,.true.)
-c      write(*,'(a,1p6g15.7)')'temit-etwiss-ent ',
-c     $       tw(mfitax:mfitny)/[1d0,1d0,m_2pi,1d0,1d0,m_2pi]
       dceig=ceig-ceig0
       dc=sum(abs(dceig))
       cc(1:5:2)=ceig(1:5:2)
@@ -434,6 +432,7 @@ c     enddo
             ab(i)=1.d0
           endif
         enddo
+c        write(*,'(a,1p5G15.7)')'tecalc-3 ',btr(1,1),btr(1,3),btr(3,3),beam(1),beam(3)
         call tsolva(btr,beam,emitn,21,21,21,1d-8)
         do i=1,5,2
           k1=iaidx(i,i)
@@ -600,15 +599,16 @@ c      write(*,'(1p10g12.4)')spt
         iret=3
         return
       else
+c        write(*,'(a,1p5G15.7)')'intraconv-1 ',eemx,eemy,eemz,emz0,coumin
         emmin=(eemx+eemy)*coumin
         eemx=max(emmin,eemx)
         eemy=max(emmin,eemy)
         eemz=max(emz0*0.1d0,eemz)
         if(eemx .le. 0.d0 .or. eemy .le. 0.d0 .or. eemz .le. 0.d0)then
-          write(lfno,'(2a,/,a,1p3g15.7/)')
+          write(lfno,'(2a,/,a,1p3g15.7,a,i5/)')
      $         ' Negative emittance, ',
      $         'No intrabeam/space charge calculation:',
-     $         'eem(x,y,z) =',eemx,eemy,eemz
+     $         'eem(x,y,z) =',eemx,eemy,eemz,', iter =',it
           it=itmax+1
         else
           eemx=min(emxmax,max(emxmin,eemx))
@@ -623,7 +623,7 @@ c      write(*,'(1p10g12.4)')spt
               write(*,*)
      $     '     EMITX          EMITY          EMITZ           conv'
             endif
-            write(*,'(1p4G15.7)')eemx,eemy,eemz,de
+c            write(*,'(1p4G15.7)')eemx,eemy,eemz,de
           endif
         endif
       endif

--- a/src/tfefun.f
+++ b/src/tfefun.f
@@ -345,7 +345,6 @@
           endif
         endif
         if(ktfsymbolq(ki,symi))then
-c          write(*,*)'dsethead ',symi%loc,symi%gen
           if(symi%loc .eq. sym%loc
      $         .and. max(0,symi%gen) .eq. max(0,sym%gen))then
             kh=ki0
@@ -387,8 +386,7 @@ c          write(*,*)'dsethead ',symi%loc,symi%gen
       call tfgetllstk(kln,2,-1)
       isp2=isp
       listl=>tfclonelist(listl)
-      call tfpartrstk(listl,isp1,isp2,list,
-     $     .false.,.true.,eval,.true.,irtc)
+      call tfpartrstk(listl,isp1,isp2,list,.false.,.true.,eval,.true.,irtc)
       if(irtc .ne. 0)then
         return
       endif
@@ -1258,7 +1256,6 @@ c      include 'DEBUG.inc'
       case (mtfslot,mtfslotseq)
         if(ktfrealq(ky,vy))then
           ks=int8(vy)
-c          write(*,*)'tfeexpr-slot ',vy,ks
           if(dble(ks) .ne. vy) then
             go to 5000
           endif

--- a/src/tffs.f
+++ b/src/tffs.f
@@ -1345,7 +1345,7 @@ c              akk=sqrt(cmp%value(ky_K1_MULT)**2+sk1**2)/al
             cmp%lvalue(n+1,p_DOFR_MULT)=
      $           merge(merge(.true.,
      $           hypot(cmp%value(ky_K0_MULT+n*2),
-     $           cmp%value(ky_K0_MULT+n*2))/al*ampmaxm**(n+1)*aninv(n+1)
+     $           cmp%value(ky_SK0_MULT+n*2))/al*ampmaxm**(n+1)*aninv(n+1)
      $           > eps,n <= 2),.false.,
      $           cmp%value(ky_K0_MULT+n*2) /= 0.d0
      $           .or. cmp%value(ky_SK0_MULT+n*2) /= 0.d0)

--- a/src/tfmodule.f
+++ b/src/tfmodule.f
@@ -15,7 +15,7 @@
       logical*4 ,intent(in):: module,eval
       logical*4 rep
       kx=dxnullo
-      if(isp .ne. isp1+2)then
+      if(isp /= isp1+2)then
         irtc=itfmessage(9,'General::narg','"2"')
         return
       endif
@@ -28,7 +28,7 @@
       endif
       isp0=isp
       call tfmlocalv(lvlist,module,eval,irtc)
-      if(irtc .ne. 0)then
+      if(irtc /= 0)then
         if(eval)then
           go to 9200
         else
@@ -47,7 +47,7 @@
       elseif(module)then
         call tfreplacesymbolstk(dtastk(isp0),isp0,(isp2-isp0)/2,ke,
      $     .false.,rep,irtc)
-        if(irtc .ne. 0)then
+        if(irtc /= 0)then
           isp=isp2
           go to 9200
         endif
@@ -62,7 +62,7 @@ c          call tfdebugprint(kx,'tfmodule-1',1)
         endif
         isp=isp2
       elseif(rep)then
-        if(isp2 .gt. isp0)then
+        if(isp2 > isp0)then
           kxl1=tfredefslist(isp0,isp2,lvlist)
 c          call tfdebugprint(kxl1,'==>',2)
         else
@@ -103,14 +103,14 @@ c        call tfdebugprint(dtastk(i),'tfmodule-delete',1)
       integer*4 i,kk,irtc,isp0
       logical*4 ,intent(in):: del,unset
       if(unset)then
-        if(def%upval .ne. 0)then
+        if(def%upval /= 0)then
           isp0=isp
           isp=isp+1
           ktastk(isp)=ktfoper+mtfunset
           isp=isp+1
           dtastk(isp)=sad_descr(def%sym)
           kx=tfefunrefu(isp0+1,irtc)
-          if(irtc .ne. 0 .and. ierrorprint .ne. 0)then
+          if(irtc /= 0 .and. ierrorprint /= 0)then
             call tfreseterror
           endif
           isp=isp0
@@ -119,13 +119,13 @@ c        call tfdebugprint(dtastk(i),'tfmodule-delete',1)
       ka1=def%upval
       def%upval=0
       do kk=1,2
-        do while(ka1 .ne. 0)
+        do while(ka1 /= 0)
           call loc_defhash(ka1,dhash)
           ka10=dhash%next
           if(dhash%gen .eq. maxgeneration)then
             do i=0,dhash%nhash
               kadi=dhash%dhash(i)%k
-              do while(kadi .ne. 0)
+              do while(kadi /= 0)
                 kadi0=klist(kadi)
                 call tfcleardaloc(kadi)
                 call tfree(kadi)
@@ -145,7 +145,7 @@ c        call tfdebugprint(dtastk(i),'tfmodule-delete',1)
       if(del)then
         kp0=def%prev
         kp1=def%next
-        if(kp1 .ne. 0)then
+        if(kp1 /= 0)then
           call loc1_symdef(kp1,def1)
           def1%prev=kp0
           if(max(0,def1%sym%gen) .eq. max(0,def%sym%gen) .and.
@@ -189,7 +189,7 @@ c        call tfdebugprint(dtastk(i),'tfmodule-delete',1)
       integer*4 m,mi,lgi,ii,i,itfmessage,lg,isps
       integer*4 ,intent(out):: irtc
       logical*4 ,intent(in):: module,eval
-      if(list%head%k .ne. ktfoper+mtflist)then
+      if(list%head%k /= ktfoper+mtflist)then
         irtc=itfmessage(9,'General::wrongtype','"List"')
         return
       endif
@@ -216,11 +216,11 @@ c        write(*,*)'mlocalv-1'
             dtastk(isp-1)=ki
             dtastk(isp  )=kxnaloc1(lg,symi%loc)
           elseif(ktflistq(ki,kli))then
-            if(kli%head%k .ne. ktfoper+mtfset .and.
-     $           kli%head%k .ne. ktfoper+mtfsetdelayed)then
+            if(kli%head%k /= ktfoper+mtfset .and.
+     $           kli%head%k /= ktfoper+mtfsetdelayed)then
               go to 100
             endif
-            if(kli%nl .ne. 2)then
+            if(kli%nl /= 2)then
               go to 100
             endif
             ki1=kli%dbody(1)
@@ -229,13 +229,13 @@ c        write(*,*)'mlocalv-1'
               if(ktflistq(ki2,kli2))then
                 isps=isp
                 ki2=tfleval(kli2,.true.,irtc)
-                if(irtc .ne. 0)then
+                if(irtc /= 0)then
                   go to 200
                 endif
               elseif(ktfsymbolq(ki2) .or. ktfpatq(ki2))then
                 isps=isp
                 ki2=tfeevalref(ki2,irtc)
-                if(irtc .ne. 0)then
+                if(irtc /= 0)then
                   go to 200
                 endif
               endif
@@ -244,7 +244,7 @@ c        write(*,*)'mlocalv-1'
               if(kli1%head%k .eq. ktfoper+mtflist)then
                 mi=kli1%nl
                 if(tflistq(ki2,kli2))then
-                  if(kli2%nl .ne. mi)then
+                  if(kli2%nl /= mi)then
                     irtc=itfmessage(9,'General::equalleng',
      $                   'lhs and rhs of Set')
                     return
@@ -305,11 +305,11 @@ c        write(*,*)'mlocalv-1'
             dtastk(isp-1)=ki
             dtastk(isp  )=dxsycopy(symi)
           elseif(ktflistq(ki,kli))then
-            if(kli%head%k .ne. ktfoper+mtfset .and.
-     $           kli%head%k .ne. ktfoper+mtfsetdelayed)then
+            if(kli%head%k /= ktfoper+mtfset .and.
+     $           kli%head%k /= ktfoper+mtfsetdelayed)then
               go to 100
             endif
-            if(kli%nl .ne. 2)then
+            if(kli%nl /= 2)then
               go to 100
             endif
             ki1=kli%dbody(1)
@@ -416,7 +416,7 @@ c        write(*,*)'mlocalv-1'
       integer*4 isp2,i,itfmessage,lg0,n
       logical*4 rep,symbol
       logical*4 ,intent(in):: eval
-      if(isp .ne. isp1+2)then
+      if(isp /= isp1+2)then
         irtc=itfmessage(9,'General::narg','"2"')
         return
       endif
@@ -427,7 +427,7 @@ c        write(*,*)'mlocalv-1'
       irtc=0
       isp2=isp
       lg0=lgeneration
-      if(list%nl .gt. 0)then
+      if(list%nl > 0)then
         symbol=.true.
         do i=1,list%nl
           isp=isp+2
@@ -477,7 +477,7 @@ c        write(*,*)'mlocalv-1'
             else
               kxi=tfeevalref(ki,irtc)
             endif
-            if(irtc .ne. 0)then
+            if(irtc /= 0)then
               isp=isp2
               return
             endif
@@ -498,12 +498,12 @@ c        write(*,*)'mlocalv-1'
      $           isp2,list%nl,.true.,rep,irtc)
             call tfresetrule(isp2,list%nl)
           endif
-          if(irtc .ne. 0)then
+          if(irtc /= 0)then
             isp=isp2
             return
           endif
         else
-          if(isp .gt. isp2)then
+          if(isp > isp2)then
             n=(isp-isp2)/2;
             isp=isp+1
             call tfreplacesymbolstk(dtastk(isp1+1),isp2,n,dtastk(isp),
@@ -577,7 +577,7 @@ c        write(*,*)'mlocalv-1'
         rep=rep .or. rep1
         kd=tfredefsymbol(isp1,isp2,pat%default,rep1)
         rep=rep .or. rep1
-        if(pat%sym%loc .ne. 0)then
+        if(pat%sym%loc /= 0)then
           ks=pat%sym%alloc
           kas=ktfaddr(ks)
           do i=isp1,isp2-1,2

--- a/src/tfpart.f
+++ b/src/tfpart.f
@@ -169,8 +169,7 @@
               call tfreplist(lar,iv,sad_descr(lari),eval1)
               eval=eval .or. eval1
             endif
-            call tfpartrstk(lari,isp1+1,isp2,
-     $           list,last,write,eval1,err,irtc)
+            call tfpartrstk(lari,isp1+1,isp2,list,last,write,eval1,err,irtc)
             eval=eval .or. eval1
           else
             go to 9040
@@ -270,7 +269,7 @@
             if(write)then
               ka=sad_loc(lar%head)
               ktastk(isp+1:isp+ma)=ka
-              itastk(1,isp+1:isp+ma)=[(i,i=1,ma)]
+              itastk2(1,isp+1:isp+ma)=[(i,i=1,ma)]
               isp=isp+ma
 c              do i=1,ma
 c                isp=isp+1

--- a/src/tintrb.f
+++ b/src/tintrb.f
@@ -41,7 +41,7 @@ c      parameter (eeuler=7.98221278918726d0,a=5.5077d0,b=1.1274d0)
       real*8 ,intent(out):: bmi(21)
       real*8 ,intent(in):: al,al1
       real*8 pl(3,3),r(3,3),eig(3),xx(3,3),xxs(3,3),bint,e1,e2,e3
-      real*8 xp(3,3),transw(6,6),bmi0(21),
+      real*8 xp(3,3),transw(6,6),
      $     pxi,pyi,s,pr,pzi,alx,ale,alz,hi,a,b,d,vol,
      $     bm,ptrans,extrans,eytrans,eztrans,tf,aez,aex0,aey0,
      $     aez0,aexz,aeyz,f1,f2,f3,bn,bmax,bmin,ci,pvol,vol1,
@@ -118,7 +118,6 @@ c     real*8  vmin/0.d0/
      $       +pzi*trans2(1:6,5))/pr
         trans2(1:6,6)=pr/pzi*trans2(1:6,6)
         trans1=matmul(trans2,trans1)
-        bmi0=bmi
         call tmulbs(bmi,trans1,.false.)
         xx(1,1)=bmi(ia(1,1))
         xx(2,1)=bmi(ia(3,1))
@@ -221,17 +220,20 @@ c        call eigs33(pl,r,eig)
      1       vol/pi/(ptrans*p0/h0*c)/pbunch
      $       /max(taurdx,taurdy,taurdz)))
      1       )
-        ci=cintrb*al*log(max(1.d-300,2.d0*bmax/bmin))/vol1/pvol/h0**4
         bmi=0.d0
-        bmi(ia(2,2))=ci*pl(1,1)
-        bmi(ia(4,2))=ci*pl(2,1)
-        bmi(ia(6,2))=ci*pl(3,1)
-        bmi(ia(4,4))=ci*pl(2,2)
-        bmi(ia(6,4))=ci*pl(3,2)
-        bmi(ia(6,6))=ci*pl(3,3)
-        call tmulbs(bmi,tinv6(trans1),.false.)
-        beam(1:21)=bmi+beam(1:21)
-        call tmulbs(bmi,tinv6(trans(:,1:6)),.false.)
+        if(bmax > bmin)then
+          ci=cintrb*al*log(max(1.d-300,2.d0*bmax/bmin))/vol1/pvol/h0**4
+          bmi(ia(2,2))=ci*pl(1,1)
+          bmi(ia(4,2))=ci*pl(2,1)
+          bmi(ia(6,2))=ci*pl(3,1)
+          bmi(ia(4,4))=ci*pl(2,2)
+          bmi(ia(6,4))=ci*pl(3,2)
+          bmi(ia(6,6))=ci*pl(3,3)
+          trans2=tinv6(trans1)
+          call tmulbs(bmi,trans2,.false.)
+          beam(1:21)=bmi+beam(1:21)
+          call tmulbs(bmi,tinv6(trans(:,1:6)),.false.)
+        endif
       endif
       return
       end

--- a/src/tsgeo.f
+++ b/src/tsgeo.f
@@ -295,7 +295,7 @@ c     a14= 2.d0*sin(phi*.5d0)**2/ak
         call tmulte(trans,cod,beam,srot,i,al,
      $       dummy,
      $       bzs*dir,
-     $       0.d0,0.d0,0.d0,0.d0,
+     $       0.d0,0.d0,0.d0,0.d0,0.d0,
      1       cmp%value(ky_DX_CAVI),cmp%value(ky_DY_CAVI),
      $       0.d0,0.d0,0.d0,
      $       cmp%value(ky_ROT_CAVI),


### PR DESCRIPTION
Fixed (thank so who pointed out):
1. Setting to a list caused seg fault when the last index is Null (Tao Liu).
2. Duplicated rotation and shift of BEND with L=0 (Li Zhiyuan, through item 6 below).
3. Argument mismatch on calling tquad from tbend when ANGLE+K0=0.
4. Argument mismatch on calling tmulti from tbend when ANGLE = 0.
5. Argument mismatch on calling tmulte from tsgeo, for CAV within SOL.
6. Ignored SKn in MULT to determine the necessity of fringe calculation.

Changes:
1. The automatic numerical derivative when CELL and unstable optics is now turned off. Set FFS$NumericalDerivative=True if needed.